### PR TITLE
Update to semantic-ui-react 0.68.4-0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,14 @@
+## 0.3.0
+
+* targets semantic-ui-react version "0.68.4-0"
+
 ## 0.2.0
 
 * targets semantic-ui-react version "0.64.0-0"
+* recommended css - <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.2/semantic.min.css">
 
---- 
+---
 
-*DONT USE ANYTHING BEFORE VERSION 0.2.0.* 
+*DONT USE ANYTHING BEFORE VERSION 0.2.0.*
 
 The previous versions were incomplete and wrapped semantic-ui instead of semantic-ui-react.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following stylesheet to your *index.html*:
 Put the following in the `:dependencies` vector of your *project.clj*
 
 ```clojure
-[soda-ash "0.2.0"]
+[soda-ash "0.3.0"]
 ```
 
 Then require soda-ash in your namespace.
@@ -58,7 +58,7 @@ However, in clojurescript with soda-ash, you'd write something like this:
   (:require
    [reagent.core :as reagent]
    [soda-ash.core :as sa]))
-   
+
 (defn modal-example []
   [sa/Modal {:trigger (reagent/as-element [sa/Button "Show Modal"])}
    [sa/ModalHeader "Select a Photo"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject soda-ash "0.2.0"
+(defproject soda-ash "0.3.0"
   :description "Soda-ash is an interface between clojurescript's reagent
                 and Semantic UI React"
   :url "https://github.com/gadfly361/soda-ash"
@@ -12,4 +12,4 @@
   [[org.clojure/clojure "1.8.0"]
    [org.clojure/clojurescript "1.9.229"]
    [reagent "0.6.0"]
-   [cljsjs/semantic-ui-react "0.64.0-0"]])
+   [cljsjs/semantic-ui-react "0.68.4-0"]])

--- a/src/soda_ash/macros.clj
+++ b/src/soda_ash/macros.clj
@@ -5,6 +5,7 @@
   '[Accordion
     AccordionContent
     AccordionTitle
+    Advertisement
     Breadcrumb
     BreadcrumbDivider
     BreadcrumbSection
@@ -141,7 +142,8 @@
     TableHeader
     TableHeaderCell
     TableRow
-    TextArea])
+    TextArea
+    Visibility])
 
 
 (def reserved-tags #{"Comment"


### PR DESCRIPTION
- Updated to latest semantic-ui-react that cljsjs had available
-Added `Visibility` and `Advertisement` to `semantic-ui-react-tags`