### PR TITLE
Update semantic-ui to 0.72.0, add new tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+* targets semantic-ui-react version "0.72.0-0"
+
 ## 0.3.0
 
 * targets semantic-ui-react version "0.68.4-0"

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ and [semantic-ui-react](http://react.semantic-ui.com/introduction).
 Add the following stylesheet to your *index.html*:
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/semantic.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css">
 ```
 
 
 Put the following in the `:dependencies` vector of your *project.clj*
 
 ```clojure
-[soda-ash "0.3.0"]
+[soda-ash "0.4.0"]
 ```
 
 Then require soda-ash in your namespace.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject soda-ash "0.3.0"
+(defproject soda-ash "0.4.0"
   :description "Soda-ash is an interface between clojurescript's reagent
                 and Semantic UI React"
   :url "https://github.com/gadfly361/soda-ash"
@@ -12,4 +12,4 @@
   [[org.clojure/clojure "1.8.0"]
    [org.clojure/clojurescript "1.9.229"]
    [reagent "0.6.0"]
-   [cljsjs/semantic-ui-react "0.68.4-0"]])
+   [cljsjs/semantic-ui-react "0.72.0-0"]])

--- a/src/soda_ash/macros.clj
+++ b/src/soda_ash/macros.clj
@@ -39,6 +39,7 @@
     DropdownHeader
     DropdownItem
     DropdownMenu
+    DropdownSearchInput
     Embed
     Feed
     FeedContent
@@ -135,6 +136,8 @@
     StepDescription
     StepGroup
     StepTitle
+    Sticky
+    Tab
     Table
     TableBody
     TableCell
@@ -143,6 +146,7 @@
     TableHeaderCell
     TableRow
     TextArea
+    Transition
     Visibility])
 
 


### PR DESCRIPTION
Update semantic-ui to 0.72.0
Add tags for DropdownSearchInput, Sticky, Tab, and Transition components 